### PR TITLE
improve fork behavior

### DIFF
--- a/src/Fast.xs
+++ b/src/Fast.xs
@@ -221,10 +221,7 @@ int Redis__Cluster__Fast_connect(Redis__Cluster__Fast self){
         return 1;
     }
 
-    struct event_config *cfg;
-    cfg = event_config_new();
-    event_config_set_flag(cfg, EVENT_BASE_FLAG_EPOLL_USE_CHANGELIST);
-    self->cluster_event_base = event_base_new_with_config(cfg);
+    self->cluster_event_base = event_base_new();
     redisClusterLibeventAttach(self->acc, self->cluster_event_base);
 
     DEBUG_MSG("%s", "done connect");

--- a/src/Fast.xs
+++ b/src/Fast.xs
@@ -246,6 +246,7 @@ void Redis__Cluster__Fast_run_cmd(Redis__Cluster__Fast self, int argc, const cha
             reply_t->error = "event reinit failed";
             return;
         }
+        redisClusterAsyncDisconnect(self->acc);
         self->pid = current_pid;
     }
 

--- a/src/Fast.xs
+++ b/src/Fast.xs
@@ -244,7 +244,6 @@ void Redis__Cluster__Fast_run_cmd(Redis__Cluster__Fast self, int argc, const cha
         DEBUG_MSG("%s", "pid changed");
         if (event_reinit(self->cluster_event_base) != 0) {
             reply_t->error = "event reinit failed";
-            DEBUG_MSG("%s", reply_t->error);
             return;
         }
         self->pid = current_pid;


### PR DESCRIPTION
When forking, the entire cluster async context was recreated, but it was useless(slow) because the number of cluster nodes issued increased. 

I want to realize fork safe by reusing the cluster async context.