### PR TITLE
Add simple microbenchmark example (It's rough)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,30 @@ Require Redis 6 or higher to support [RESP3](https://github.com/antirez/RESP3/bl
 
 To build this module you need at least autoconf, automake, libtool, patch, pkg-config are installed on your system.
 
+## MICROBENCHMARK
+
+Simple microbenchmark comparing PP and XS.
+The benchmark script used can be found under example directory.
+
+    Redis::Cluster::Fast is 0.084
+    Redis::ClusterRider is 0.26
+    ### mset ###
+                            Rate  Redis::ClusterRider Redis::Cluster::Fast
+    Redis::ClusterRider  12821/s                   --                 -32%
+    Redis::Cluster::Fast 18762/s                  46%                   --
+    ### mget ###
+                            Rate  Redis::ClusterRider Redis::Cluster::Fast
+    Redis::ClusterRider  14815/s                   --                 -41%
+    Redis::Cluster::Fast 24938/s                  68%                   --
+    ### incr ###
+                            Rate  Redis::ClusterRider Redis::Cluster::Fast
+    Redis::ClusterRider  17830/s                   --                 -46%
+    Redis::Cluster::Fast 33051/s                  85%                   --
+    ### new ###
+                           Rate  Redis::ClusterRider Redis::Cluster::Fast
+    Redis::ClusterRider   155/s                   --                 -96%
+    Redis::Cluster::Fast 3900/s                2415%                   --
+
 # METHODS
 
 ## new(%args)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To build this module you need at least autoconf, automake, libtool, patch, pkg-c
 ## MICROBENCHMARK
 
 Simple microbenchmark comparing PP and XS.
-The benchmark script used can be found under example directory.
+The benchmark script used can be found under examples directory.
 
     Redis::Cluster::Fast is 0.084
     Redis::ClusterRider is 0.26

--- a/README.md
+++ b/README.md
@@ -58,20 +58,20 @@ The benchmark script used can be found under example directory.
     Redis::ClusterRider is 0.26
     ### mset ###
                             Rate  Redis::ClusterRider Redis::Cluster::Fast
-    Redis::ClusterRider  12821/s                   --                 -32%
-    Redis::Cluster::Fast 18762/s                  46%                   --
+    Redis::ClusterRider  13245/s                   --                 -34%
+    Redis::Cluster::Fast 20080/s                  52%                   --
     ### mget ###
                             Rate  Redis::ClusterRider Redis::Cluster::Fast
-    Redis::ClusterRider  14815/s                   --                 -41%
-    Redis::Cluster::Fast 24938/s                  68%                   --
+    Redis::ClusterRider  14641/s                   --                 -40%
+    Redis::Cluster::Fast 24510/s                  67%                   --
     ### incr ###
                             Rate  Redis::ClusterRider Redis::Cluster::Fast
-    Redis::ClusterRider  17830/s                   --                 -46%
-    Redis::Cluster::Fast 33051/s                  85%                   --
-    ### new ###
+    Redis::ClusterRider  18367/s                   --                 -44%
+    Redis::Cluster::Fast 32879/s                  79%                   --
+    ### new and ping ###
                            Rate  Redis::ClusterRider Redis::Cluster::Fast
-    Redis::ClusterRider   155/s                   --                 -96%
-    Redis::Cluster::Fast 3900/s                2415%                   --
+    Redis::ClusterRider   146/s                   --                 -96%
+    Redis::Cluster::Fast 3941/s                2598%                   --
 
 # METHODS
 

--- a/examples/benchmark-simple.pl
+++ b/examples/benchmark-simple.pl
@@ -13,7 +13,7 @@ use Test::More; # for Test::RedisCluster
 use Test::RedisCluster qw/get_startup_nodes/;
 my $nodes = get_startup_nodes;
 
-print "Redis::Fast is " . $Redis::Cluster::Fast::VERSION . "\n";
+print "Redis::Cluster::Fast is " . $Redis::Cluster::Fast::VERSION . "\n";
 print "Redis::ClusterRider is " . $Redis::ClusterRider::VERSION . "\n";
 
 my $xs = Redis::Cluster::Fast->new(

--- a/examples/benchmark-simple.pl
+++ b/examples/benchmark-simple.pl
@@ -1,0 +1,107 @@
+use strict;
+use warnings FATAL => 'all';
+
+use lib "./_build/lib";
+use lib "./blib/arch";
+use lib "./blib/lib";
+use lib "./t/lib";
+
+use Benchmark;
+use Redis::Cluster::Fast;
+use Redis::ClusterRider;
+use Test::More; # for Test::RedisCluster
+use Test::RedisCluster qw/get_startup_nodes/;
+my $nodes = get_startup_nodes;
+
+print "Redis::Fast is " . $Redis::Cluster::Fast::VERSION . "\n";
+print "Redis::ClusterRider is " . $Redis::ClusterRider::VERSION . "\n";
+
+my $xs = Redis::Cluster::Fast->new(
+    startup_nodes => $nodes,
+);
+
+my $pp = Redis::ClusterRider->new(
+    startup_nodes => $nodes,
+);
+
+my $cc = 0;
+my $dd = 0;
+
+my $loop = 100000;
+print "### mset ###\n";
+Benchmark::cmpthese($loop, {
+    "Redis::ClusterRider" => sub {
+        $cc++;
+        $pp->mset("{pp$cc}atest", $cc, "{pp$cc}btest", $cc, "{pp$cc}ctest", $cc);
+    },
+    "Redis::Cluster::Fast" => sub {
+        $dd++;
+        $xs->mset("{xs$dd}atest", $dd, "{xs$dd}btest", $dd, "{xs$dd}ctest", $dd);
+    },
+});
+
+$cc = 0;
+$dd = 0;
+
+print "### mget ###\n";
+Benchmark::cmpthese($loop, {
+    "Redis::ClusterRider" => sub {
+        $cc++;
+        $pp->mget("{pp$cc}atest", "{pp$cc}btest", "{pp$cc}ctest");
+    },
+    "Redis::Cluster::Fast" => sub {
+        $dd++;
+        $xs->mget("{xs$dd}atest", "{xs$dd}btest", "{xs$dd}ctest");
+    },
+});
+
+print "### incr ###\n";
+Benchmark::cmpthese(-2, {
+    "Redis::ClusterRider" => sub {
+        $pp->incr("incr_1");
+    },
+    "Redis::Cluster::Fast" => sub {
+        $xs->incr("incr_2");
+    },
+});
+
+print "### new ###\n";
+Benchmark::cmpthese(-2, {
+    "Redis::ClusterRider" => sub {
+        my $tmp = Redis::ClusterRider->new(
+            startup_nodes => $nodes,
+        );
+        $tmp->ping;
+    },
+    "Redis::Cluster::Fast" => sub {
+        my $tmp = Redis::Cluster::Fast->new(
+            startup_nodes => $nodes,
+        );
+        $tmp->ping;
+    },
+});
+
+is 1, 1;
+done_testing;
+__END__
+% perl ./examples/benchmark-simple.pl
+Redis::Fast is 0.082
+Redis::ClusterRider is 0.26
+### mset ###
+                        Rate  Redis::ClusterRider Redis::Cluster::Fast
+Redis::ClusterRider  13477/s                   --                 -26%
+Redis::Cluster::Fast 18182/s                  35%                   --
+### mget ###
+                        Rate  Redis::ClusterRider Redis::Cluster::Fast
+Redis::ClusterRider  14347/s                   --                 -40%
+Redis::Cluster::Fast 23923/s                  67%                   --
+### incr ###
+                        Rate  Redis::ClusterRider Redis::Cluster::Fast
+Redis::ClusterRider  16654/s                   --                 -51%
+Redis::Cluster::Fast 34037/s                 104%                   --
+### new ###
+                       Rate  Redis::ClusterRider Redis::Cluster::Fast
+Redis::ClusterRider   157/s                   --                 -96%
+Redis::Cluster::Fast 3801/s                2328%                   --
+ok 1
+1..1

--- a/examples/benchmark-simple.pl
+++ b/examples/benchmark-simple.pl
@@ -61,7 +61,7 @@ Benchmark::cmpthese(-2, {
     },
 });
 
-print "### new ###\n";
+print "### new and ping ###\n";
 Benchmark::cmpthese(-2, {
     "Redis::ClusterRider" => sub {
         my $tmp = Redis::ClusterRider->new(
@@ -85,19 +85,19 @@ Redis::Cluster::Fast is 0.084
 Redis::ClusterRider is 0.26
 ### mset ###
                         Rate  Redis::ClusterRider Redis::Cluster::Fast
-Redis::ClusterRider  12821/s                   --                 -32%
-Redis::Cluster::Fast 18762/s                  46%                   --
+Redis::ClusterRider  13245/s                   --                 -34%
+Redis::Cluster::Fast 20080/s                  52%                   --
 ### mget ###
                         Rate  Redis::ClusterRider Redis::Cluster::Fast
-Redis::ClusterRider  14815/s                   --                 -41%
-Redis::Cluster::Fast 24938/s                  68%                   --
+Redis::ClusterRider  14641/s                   --                 -40%
+Redis::Cluster::Fast 24510/s                  67%                   --
 ### incr ###
                         Rate  Redis::ClusterRider Redis::Cluster::Fast
-Redis::ClusterRider  17830/s                   --                 -46%
-Redis::Cluster::Fast 33051/s                  85%                   --
-### new ###
+Redis::ClusterRider  18367/s                   --                 -44%
+Redis::Cluster::Fast 32879/s                  79%                   --
+### new and ping ###
                        Rate  Redis::ClusterRider Redis::Cluster::Fast
-Redis::ClusterRider   155/s                   --                 -96%
-Redis::Cluster::Fast 3900/s                2415%                   --
+Redis::ClusterRider   146/s                   --                 -96%
+Redis::Cluster::Fast 3941/s                2598%                   --
 ok 1
 1..1

--- a/examples/benchmark-simple.pl
+++ b/examples/benchmark-simple.pl
@@ -1,20 +1,16 @@
 use strict;
 use warnings FATAL => 'all';
-
-use lib "./_build/lib";
-use lib "./blib/arch";
-use lib "./blib/lib";
-use lib "./t/lib";
-
+use lib './t/lib';
 use Benchmark;
 use Redis::Cluster::Fast;
 use Redis::ClusterRider;
 use Test::More; # for Test::RedisCluster
-use Test::RedisCluster qw/get_startup_nodes/;
-my $nodes = get_startup_nodes;
+use Test::Docker::RedisCluster qw/get_startup_nodes/;
 
 print "Redis::Cluster::Fast is " . $Redis::Cluster::Fast::VERSION . "\n";
 print "Redis::ClusterRider is " . $Redis::ClusterRider::VERSION . "\n";
+
+my $nodes = get_startup_nodes;
 
 my $xs = Redis::Cluster::Fast->new(
     startup_nodes => $nodes,

--- a/examples/benchmark-simple.pl
+++ b/examples/benchmark-simple.pl
@@ -80,24 +80,24 @@ Benchmark::cmpthese(-2, {
 is 1, 1;
 done_testing;
 __END__
-% perl ./examples/benchmark-simple.pl
-Redis::Fast is 0.082
+% AUTOMATED_TESTING=1 perl ./examples/benchmark-simple.pl
+Redis::Cluster::Fast is 0.084
 Redis::ClusterRider is 0.26
 ### mset ###
                         Rate  Redis::ClusterRider Redis::Cluster::Fast
-Redis::ClusterRider  13477/s                   --                 -26%
-Redis::Cluster::Fast 18182/s                  35%                   --
+Redis::ClusterRider  12821/s                   --                 -32%
+Redis::Cluster::Fast 18762/s                  46%                   --
 ### mget ###
                         Rate  Redis::ClusterRider Redis::Cluster::Fast
-Redis::ClusterRider  14347/s                   --                 -40%
-Redis::Cluster::Fast 23923/s                  67%                   --
+Redis::ClusterRider  14815/s                   --                 -41%
+Redis::Cluster::Fast 24938/s                  68%                   --
 ### incr ###
                         Rate  Redis::ClusterRider Redis::Cluster::Fast
-Redis::ClusterRider  16654/s                   --                 -51%
-Redis::Cluster::Fast 34037/s                 104%                   --
+Redis::ClusterRider  17830/s                   --                 -46%
+Redis::Cluster::Fast 33051/s                  85%                   --
 ### new ###
                        Rate  Redis::ClusterRider Redis::Cluster::Fast
-Redis::ClusterRider   157/s                   --                 -96%
-Redis::Cluster::Fast 3801/s                2328%                   --
+Redis::ClusterRider   155/s                   --                 -96%
+Redis::Cluster::Fast 3900/s                2415%                   --
 ok 1
 1..1

--- a/lib/Redis/Cluster/Fast.pm
+++ b/lib/Redis/Cluster/Fast.pm
@@ -128,6 +128,30 @@ Require Redis 6 or higher to support L<RESP3|https://github.com/antirez/RESP3/bl
 
 To build this module you need at least autoconf, automake, libtool, patch, pkg-config are installed on your system.
 
+=head2 MICROBENCHMARK
+
+Simple microbenchmark comparing PP and XS.
+The benchmark script used can be found under example directory.
+
+    Redis::Cluster::Fast is 0.084
+    Redis::ClusterRider is 0.26
+    ### mset ###
+                            Rate  Redis::ClusterRider Redis::Cluster::Fast
+    Redis::ClusterRider  12821/s                   --                 -32%
+    Redis::Cluster::Fast 18762/s                  46%                   --
+    ### mget ###
+                            Rate  Redis::ClusterRider Redis::Cluster::Fast
+    Redis::ClusterRider  14815/s                   --                 -41%
+    Redis::Cluster::Fast 24938/s                  68%                   --
+    ### incr ###
+                            Rate  Redis::ClusterRider Redis::Cluster::Fast
+    Redis::ClusterRider  17830/s                   --                 -46%
+    Redis::Cluster::Fast 33051/s                  85%                   --
+    ### new ###
+                           Rate  Redis::ClusterRider Redis::Cluster::Fast
+    Redis::ClusterRider   155/s                   --                 -96%
+    Redis::Cluster::Fast 3900/s                2415%                   --
+
 =head1 METHODS
 
 =head2 new(%args)

--- a/lib/Redis/Cluster/Fast.pm
+++ b/lib/Redis/Cluster/Fast.pm
@@ -137,20 +137,20 @@ The benchmark script used can be found under example directory.
     Redis::ClusterRider is 0.26
     ### mset ###
                             Rate  Redis::ClusterRider Redis::Cluster::Fast
-    Redis::ClusterRider  12821/s                   --                 -32%
-    Redis::Cluster::Fast 18762/s                  46%                   --
+    Redis::ClusterRider  13245/s                   --                 -34%
+    Redis::Cluster::Fast 20080/s                  52%                   --
     ### mget ###
                             Rate  Redis::ClusterRider Redis::Cluster::Fast
-    Redis::ClusterRider  14815/s                   --                 -41%
-    Redis::Cluster::Fast 24938/s                  68%                   --
+    Redis::ClusterRider  14641/s                   --                 -40%
+    Redis::Cluster::Fast 24510/s                  67%                   --
     ### incr ###
                             Rate  Redis::ClusterRider Redis::Cluster::Fast
-    Redis::ClusterRider  17830/s                   --                 -46%
-    Redis::Cluster::Fast 33051/s                  85%                   --
-    ### new ###
+    Redis::ClusterRider  18367/s                   --                 -44%
+    Redis::Cluster::Fast 32879/s                  79%                   --
+    ### new and ping ###
                            Rate  Redis::ClusterRider Redis::Cluster::Fast
-    Redis::ClusterRider   155/s                   --                 -96%
-    Redis::Cluster::Fast 3900/s                2415%                   --
+    Redis::ClusterRider   146/s                   --                 -96%
+    Redis::Cluster::Fast 3941/s                2598%                   --
 
 =head1 METHODS
 

--- a/lib/Redis/Cluster/Fast.pm
+++ b/lib/Redis/Cluster/Fast.pm
@@ -131,7 +131,7 @@ To build this module you need at least autoconf, automake, libtool, patch, pkg-c
 =head2 MICROBENCHMARK
 
 Simple microbenchmark comparing PP and XS.
-The benchmark script used can be found under example directory.
+The benchmark script used can be found under examples directory.
 
     Redis::Cluster::Fast is 0.084
     Redis::ClusterRider is 0.26


### PR DESCRIPTION
The environment is ...

```
% cat /proc/cpuinfo | ag 'model name' | uniq -c
      8 model name	: Intel(R) Core(TM) i7-4770 CPU @ 3.40GHz
% cat /proc/meminfo | ag MemTotal
MemTotal:       16320908 kB
% uname -srvpo
Linux 5.19.0-32-generic #33~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Mon Jan 30 17:03:34 UTC 2 x86_64 GNU/Linux
```