### PR TITLE
Refactor changes by "Focus XS on glue code"

### DIFF
--- a/lib/Redis/Cluster/Fast.pm
+++ b/lib/Redis/Cluster/Fast.pm
@@ -47,11 +47,6 @@ sub AUTOLOAD {
 
     my $method = sub {
         my $self = shift;
-        grep {
-            utf8::downgrade($_, 1)
-                or confess 'command sent is not an octet sequence in the native encoding (Latin-1).';
-        } @_;
-
         my ($reply, $error) = $self->__std_cmd(@command, @_);
         confess "[$command] $error" if defined $error;
         if (wantarray) {

--- a/lib/Redis/Cluster/Fast.pm
+++ b/lib/Redis/Cluster/Fast.pm
@@ -47,7 +47,13 @@ sub AUTOLOAD {
 
     my $method = sub {
         my $self = shift;
-        my ($reply, $error) = $self->__std_cmd(@command, @_);
+        my @arguments = @_;
+        for my $index (0 .. $#arguments) {
+            utf8::downgrade($arguments[$index], 1)
+                or confess 'command sent is not an octet sequence in the native encoding (Latin-1).';
+        }
+
+        my ($reply, $error) = $self->__std_cmd(@command, @arguments);
         confess "[$command] $error" if defined $error;
         if (wantarray) {
             my $type = ref $reply;

--- a/src/Fast.xs
+++ b/src/Fast.xs
@@ -368,12 +368,6 @@ PPCODE:
     Newx(result_context, sizeof(cmd_reply_context_t), cmd_reply_context_t);
 
     for (i = 0; i < argc; i++) {
-        if(!sv_utf8_downgrade(ST(i + 1), 1)) {
-            Safefree(argv);
-            Safefree(argvlen);
-            Safefree(result_context);
-            croak("command sent is not an octet sequence in the native encoding (Latin-1).");
-        }
         argv[i] = SvPV(ST(i + 1), len);
         argvlen[i] = len;
     }

--- a/src/Fast.xs
+++ b/src/Fast.xs
@@ -368,9 +368,14 @@ PPCODE:
     Newx(result_context, sizeof(cmd_reply_context_t), cmd_reply_context_t);
 
     for (i = 0; i < argc; i++) {
+        if(!sv_utf8_downgrade(ST(i + 1), 1)) {
+            croak("command sent is not an octet sequence in the native encoding (Latin-1). Consider using debug mode to see the command itself.");
+        }
         argv[i] = SvPV(ST(i + 1), len);
         argvlen[i] = len;
     }
+
+    DEBUG_MSG("raw_cmd : %s", *argv);
 
     Redis__Cluster__Fast_run_cmd(aTHX_ self, argc, (const char **) argv, argvlen, result_context);
 

--- a/src/Fast.xs
+++ b/src/Fast.xs
@@ -369,6 +369,9 @@ PPCODE:
 
     for (i = 0; i < argc; i++) {
         if(!sv_utf8_downgrade(ST(i + 1), 1)) {
+            Safefree(argv);
+            Safefree(argvlen);
+            Safefree(result_context);
             croak("command sent is not an octet sequence in the native encoding (Latin-1).");
         }
         argv[i] = SvPV(ST(i + 1), len);

--- a/src/Fast.xs
+++ b/src/Fast.xs
@@ -375,8 +375,6 @@ PPCODE:
         argvlen[i] = len;
     }
 
-    DEBUG_MSG("raw_cmd : %s", *argv);
-
     Redis__Cluster__Fast_run_cmd(aTHX_ self, argc, (const char **) argv, argvlen, result_context);
 
     EXTEND(SP, 2);

--- a/src/Fast.xs
+++ b/src/Fast.xs
@@ -369,7 +369,7 @@ PPCODE:
 
     for (i = 0; i < argc; i++) {
         if(!sv_utf8_downgrade(ST(i + 1), 1)) {
-            croak("command sent is not an octet sequence in the native encoding (Latin-1). Consider using debug mode to see the command itself.");
+            croak("command sent is not an octet sequence in the native encoding (Latin-1).");
         }
         argv[i] = SvPV(ST(i + 1), len);
         argvlen[i] = len;

--- a/t/01_simple.t
+++ b/t/01_simple.t
@@ -32,6 +32,14 @@ ok ord($euro) > 255, 'is a wide character';
 eval {
     $redis->set('euro', $euro);
 };
-like $@, qr/^command sent is not an octet sequence in the native encoding \(Latin-1\)\./;
+like $@, qr/^command sent is not an octet sequence in the native encoding \(Latin-1\)\./, 'can not convert to Latin-1';
+
+my $to_utf8 = my $to_latin1 = "test\x{80}";
+utf8::upgrade($to_utf8);
+utf8::downgrade($to_latin1);
+is $to_utf8, $to_latin1, 'in Perl, equal';
+$redis->del($to_latin1);
+$redis->set($to_utf8, 'unicode');
+is $redis->get($to_latin1), 'unicode', 'got value will be equal';
 
 done_testing;

--- a/t/01_simple.t
+++ b/t/01_simple.t
@@ -27,4 +27,11 @@ $redis->hset('myhash', 'field1', 'Hello');
 $redis->hset('myhash', 'field2', 'ByeBye');
 is_deeply scalar $redis->hgetall('myhash'), { field1 => 'Hello', field2 => 'ByeBye' };
 
+my $euro = "\x{20ac}";
+ok ord($euro) > 255, 'is a wide character';
+eval {
+    $redis->set('euro', $euro);
+};
+like $@, qr/^command sent is not an octet sequence in the native encoding \(Latin-1\)\./;
+
 done_testing;

--- a/t/01_simple.t
+++ b/t/01_simple.t
@@ -27,11 +27,4 @@ $redis->hset('myhash', 'field1', 'Hello');
 $redis->hset('myhash', 'field2', 'ByeBye');
 is_deeply scalar $redis->hgetall('myhash'), { field1 => 'Hello', field2 => 'ByeBye' };
 
-my $euro = "\x{20ac}";
-ok ord($euro) > 255, 'is a wide character';
-eval {
-    $redis->set('euro', $euro);
-};
-like $@, qr/^command sent is not an octet sequence in the native encoding \(Latin-1\)\./;
-
 done_testing;

--- a/t/02_leak.t
+++ b/t/02_leak.t
@@ -12,6 +12,12 @@ no_leaks_ok {
     my $redis = Redis::Cluster::Fast->new(
         startup_nodes => get_startup_nodes,
     );
+
+    eval {
+        # wide character
+        $redis->set('euro', "\x{20ac}");
+    };
+
     $redis->ping;
     $redis->CLUSTER_INFO();
     $redis->eval(

--- a/t/05_valgrind.t
+++ b/t/05_valgrind.t
@@ -20,6 +20,11 @@ my $redis = Redis::Cluster::Fast->new(
 $redis->del('valgrind');
 $redis->set('valgrind', 123);
 
+eval {
+    # wide character
+    $redis->set('euro', "\x{20ac}");
+};
+
 my $pid = fork;
 if ($pid == 0) {
     # child


### PR DESCRIPTION
Reverts plainbanana/Redis-Cluster-Fast#16

~~#16 The refactor has broken the downgrade code.~~
~~Specifically, it is broken when downgrading a decoded UTF-8 string.~~

I suppose, it would not be appropriate to use 'grep' since downgrade can change the value itself.
However, it is necessary to prevent memory leaks from occurring if croak is called without releasing the 'Newx'ed variables.