### PR TITLE
Delete redundant XS macro

### DIFF
--- a/builder/MyBuilder.pm
+++ b/builder/MyBuilder.pm
@@ -93,7 +93,7 @@ sub new {
 
     $self->_build_dependencies;
 
-    $self->config(optimize => '-g O0 -fsanitize=undefined,leak -fno-sanitize-recover=all -Wall')
+    $self->config(optimize => '-g3 O0 -fsanitize=undefined,leak -fno-sanitize-recover=all -Wall')
         if is_debug;
 
     return $self;

--- a/src/Fast.xs
+++ b/src/Fast.xs
@@ -298,7 +298,7 @@ CODE:
         self->hostnames = NULL;
     }
 
-    if(hostnames) {
+    if (hostnames) {
         Newx(self->hostnames, sizeof(char) * (strlen(hostnames) + 1), char);
         strcpy(self->hostnames, hostnames);
         DEBUG_MSG("%s %s", "set hostnames", self->hostnames);
@@ -354,7 +354,7 @@ PREINIT:
     int argc, i;
 PPCODE:
 {
-    if(!self->acc) {
+    if (!self->acc) {
        croak("Not connected to any server");
     }
 

--- a/src/Fast.xs
+++ b/src/Fast.xs
@@ -274,7 +274,6 @@ redis_cluster_fast_t* self;
 PPCODE:
 {
     Newxz(self, sizeof(redis_cluster_fast_t), redis_cluster_fast_t);
-    EXTEND(SP, 1);
     ST(0) = sv_newmortal();
     sv_setref_pv(ST(0), cls, (void*)self);
     XSRETURN(1);
@@ -370,8 +369,6 @@ PPCODE:
     }
 
     Redis__Cluster__Fast_run_cmd(aTHX_ self, argc, (const char **) argv, argvlen, result_context);
-
-    EXTEND(SP, 2);
 
     ST(0) = result_context->result ?
             result_context->result : &PL_sv_undef;


### PR DESCRIPTION
There should be no need to perform EXTEND in xsubs where the number of arguments is always greater than the return value.

Even if EXTEND were to be peformed, I suppose that the stack is large enough that nothing would happen.