### PR TITLE
have tests explicitly use 127.0.0.1

### DIFF
--- a/t/lib/Test/Docker/RedisCluster.pm
+++ b/t/lib/Test/Docker/RedisCluster.pm
@@ -64,7 +64,7 @@ sub _start_redis_cluster {
     retry(2, 0,
         sub {
             ($container_id, $stderr, $exit_code) = _capture_exec(
-                qw/docker run -e BIND_ADDRESS=0.0.0.0 -d -t/,
+                qw/docker run -e IP=127.0.0.1 -d -t/,
                 '--name', TEST_DOCKER_CONTAINER_NAME,
                 '-e', $initial_port,
                 @ports,
@@ -96,7 +96,7 @@ sub get_startup_nodes {
         return [ split(/,/, $nodes) ];
     } else {
         my $ports = REDIS_CLUSTER_PORTS;
-        return [ map { "localhost:$_" } @$ports ];
+        return [ map { "127.0.0.1:$_" } @$ports ];
     }
 }
 


### PR DESCRIPTION
Hello,

When using Docker Desktop for (Mac|Windows), we cannot access `grokzen/redis-cluster` from the host machine. This problem is described [here](https://github.com/Grokzen/docker-redis-cluster#important-for-mac-users) and can be solved by specifying the `IP` environment variable.

To begin with, we are using `"localhost"` to access the cluster, so we should be able to consider `127.0.0.1` as the IP address of the cluster nodes. Furthermore, each Redis node in the docker container can access each other on 127.0.0.1. Therefore, explicitly always specifying `"127.0.0.1"` is not a problem.

Incidentally, `BIND_ADRESS` defaults to `0.0.0.0`, and as long as we use IPv4, it is unlikely that we will specify any other values during testing, so we need not set it.