### PR TITLE
fix: Avoid to dump core when giving an empty array ref as startup_nodes

### DIFF
--- a/lib/Redis/Cluster/Fast.pm
+++ b/lib/Redis/Cluster/Fast.pm
@@ -21,7 +21,7 @@ sub new {
 
     $self->__set_debug($args{debug} ? 1 : 0);
 
-    croak 'need startup_nodes' unless defined $args{startup_nodes};
+    croak 'need startup_nodes' unless defined $args{startup_nodes} && @{$args{startup_nodes}};
     if (my $servers = join(',', @{$args{startup_nodes}})) {
         $self->__set_servers($servers);
     }

--- a/t/01_simple.t
+++ b/t/01_simple.t
@@ -75,4 +75,15 @@ like $@, qr/^failed to add nodes: server port is incorrect/;
     is $redis_2->ping('PONG'), 'PONG';
 }
 
+for my $case (
+    [ undef, '^need startup_nodes' ],
+    [ [], '^need startup_nodes' ],
+    [ 'foo', '^Can\'t use string \("foo"\) as an ARRAY ref' ],
+) {
+    eval {
+        Redis::Cluster::Fast->new(startup_nodes => $case->[0]);
+    };
+    like $@, qr/$case->[1]/, 'startup_nodes validation';
+}
+
 done_testing;


### PR DESCRIPTION
Fix: #31 