### PR TITLE
Use redisClusterAsyncConnect2

### DIFF
--- a/META.json
+++ b/META.json
@@ -4,13 +4,13 @@
       "plainbanana <plainbanana@mustardon.tokyo>"
    ],
    "dynamic_config" : 0,
-   "generated_by" : "Minilla/v3.1.23, CPAN::Meta::Converter version 2.150005",
+   "generated_by" : "Minilla/v3.1.25, CPAN::Meta::Converter version 2.150010",
    "license" : [
       "perl_5"
    ],
    "meta-spec" : {
       "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
-      "version" : "2"
+      "version" : 2
    },
    "name" : "Redis-Cluster-Fast",
    "no_index" : {
@@ -76,6 +76,6 @@
    "x_contributors" : [
       "Masahiro Honma <hiratara@cpan.org>"
    ],
-   "x_serialization_backend" : "JSON::PP version 2.27300_01",
+   "x_serialization_backend" : "JSON::PP version 4.16",
    "x_static_install" : 0
 }

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Redis::Cluster::Fast - A fast perl binding for Redis Cluster
 
     use Redis::Cluster::Fast;
 
+    Redis::Cluster::Fast::srandom(100);
+
     my $redis = Redis::Cluster::Fast->new(
         startup_nodes => [
             'localhost:9000',
@@ -77,6 +79,13 @@ The benchmark script used can be found under examples directory.
     Redis::Cluster::Fast 3941/s                2598%                   --
 
 # METHODS
+
+## srandom($seed)
+
+hiredis-cluster uses [random()](https://linux.die.net/man/3/random) to select a node used for requesting cluster topology.
+
+`$seed` is expected to be an unsigned integer value,
+and is used as an argument for [srandom()](https://linux.die.net/man/3/srandom).
 
 ## new(%args)
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,11 @@ A integer value. (default: 5)
 The client will retry calling the Redis Command only if it successfully get one of the following error responses.
 MOVED, ASK, TRYAGAIN, CLUSTERDOWN.
 
-`max_retry_count` is the maximum number of retries and must be 1 or above.
+### cluster\_discovery\_retry\_timeout
+
+A fractional value. (default: 1.0)
+
+Specify the timeout value in seconds for retries when retrieves the cluster topology.
 
 ### route\_use\_slots
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ MOVED, ASK, TRYAGAIN, CLUSTERDOWN.
 
 A fractional value. (default: 1.0)
 
-Specify the timeout value in seconds for retries when retrieves the cluster topology.
+Specify the number of seconds to treat a series of cluster topology requests as timed out without retrying the operation.
+At least one operation will be attempted, and the time taken for the initial operation will also be measured.
 
 ### route\_use\_slots
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ A integer value. (default: 5)
 The client will retry calling the Redis Command only if it successfully get one of the following error responses.
 MOVED, ASK, TRYAGAIN, CLUSTERDOWN.
 
+`max_retry_count` is the maximum number of retries and must be 1 or above.
+
 ### cluster\_discovery\_retry\_timeout
 
 A fractional value. (default: 1.0)

--- a/lib/Redis/Cluster/Fast.pm
+++ b/lib/Redis/Cluster/Fast.pm
@@ -221,7 +221,8 @@ C<max_retry_count> is the maximum number of retries and must be 1 or above.
 
 A fractional value. (default: 1.0)
 
-Specify the timeout value in seconds for retries when retrieves the cluster topology.
+Specify the number of seconds to treat a series of cluster topology requests as timed out without retrying the operation.
+At least one operation will be attempted, and the time taken for the initial operation will also be measured.
 
 =head3 route_use_slots
 

--- a/lib/Redis/Cluster/Fast.pm
+++ b/lib/Redis/Cluster/Fast.pm
@@ -17,6 +17,11 @@ use constant {
 use XSLoader;
 XSLoader::load(__PACKAGE__, $VERSION);
 
+sub srandom {
+    my $seed = shift;
+    __PACKAGE__->__srandom($seed);
+}
+
 sub new {
     my ($class, %args) = @_;
     my $self = $class->_new;
@@ -103,6 +108,8 @@ Redis::Cluster::Fast - A fast perl binding for Redis Cluster
 
     use Redis::Cluster::Fast;
 
+    Redis::Cluster::Fast::srandom(100);
+
     my $redis = Redis::Cluster::Fast->new(
         startup_nodes => [
             'localhost:9000',
@@ -173,6 +180,13 @@ The benchmark script used can be found under examples directory.
     Redis::Cluster::Fast 3941/s                2598%                   --
 
 =head1 METHODS
+
+=head2 srandom($seed)
+
+hiredis-cluster uses L<random()|https://linux.die.net/man/3/random> to select a node used for requesting cluster topology.
+
+C<$seed> is expected to be an unsigned integer value,
+and is used as an argument for L<srandom()|https://linux.die.net/man/3/srandom>.
 
 =head2 new(%args)
 

--- a/lib/Redis/Cluster/Fast.pm
+++ b/lib/Redis/Cluster/Fast.pm
@@ -215,6 +215,8 @@ A integer value. (default: 5)
 The client will retry calling the Redis Command only if it successfully get one of the following error responses.
 MOVED, ASK, TRYAGAIN, CLUSTERDOWN.
 
+C<max_retry_count> is the maximum number of retries and must be 1 or above.
+
 =head3 cluster_discovery_retry_timeout
 
 A fractional value. (default: 1.0)

--- a/lib/Redis/Cluster/Fast.pm
+++ b/lib/Redis/Cluster/Fast.pm
@@ -36,6 +36,10 @@ sub new {
     $command_timeout = DEFAULT_COMMAND_TIMEOUT unless defined $command_timeout;
     $self->__set_command_timeout($command_timeout);
 
+    my $discovery_timeout = $args{cluster_discovery_retry_timeout};
+    $discovery_timeout = DEFAULT_CLUSTER_DISCOVERY_RETRY_TIMEOUT unless defined $discovery_timeout;
+    $self->__set_cluster_discovery_retry_timeout($discovery_timeout);
+
     my $max_retry = $args{max_retry_count};
     $max_retry = DEFAULT_MAX_RETRY_COUNT unless defined $max_retry;
     $self->__set_max_retry($max_retry);
@@ -45,9 +49,7 @@ sub new {
     my $error = $self->__connect();
     croak $error if $error;
 
-    my $discovery_timeout = $args{cluster_discovery_retry_timeout};
-    $discovery_timeout = DEFAULT_CLUSTER_DISCOVERY_RETRY_TIMEOUT unless defined $discovery_timeout;
-    $error = $self->__wait_until_event_ready($discovery_timeout);
+    $error = $self->__wait_until_event_ready();
     croak $error if $error;
     return $self;
 }

--- a/src/Fast.xs
+++ b/src/Fast.xs
@@ -219,6 +219,23 @@ SV *Redis__Cluster__Fast_connect(pTHX_ Redis__Cluster__Fast self) {
     return NULL;
 }
 
+SV *Redis__Cluster__Fast_disconnect(pTHX_ Redis__Cluster__Fast self) {
+    if (event_reinit(self->cluster_event_base) != 0) {
+        return newSVpvf("%s", "event reinit failed");
+    }
+    redisClusterAsyncDisconnect(self->acc);
+
+    if (event_base_dispatch(self->cluster_event_base) == -1) {
+        return newSVpvf("%s", "event_base_dispatch failed after forking");
+    }
+    event_base_free(self->cluster_event_base);
+    self->cluster_event_base = NULL;
+
+    redisClusterAsyncFree(self->acc);
+    self->acc = NULL;
+    return NULL;
+}
+
 SV *Redis__Cluster__Fast_wait_until_event_ready(pTHX_ Redis__Cluster__Fast self) {
     int event_loop_error;
     int count = 0;
@@ -262,24 +279,6 @@ cluster_node *get_node_by_random(pTHX_ Redis__Cluster__Fast self) {
             selected = candidate;
     }
     return selected;
-}
-
-void disconnect(pTHX_ Redis__Cluster__Fast self, cmd_reply_context_t *reply_t) {
-    if (event_reinit(self->cluster_event_base) != 0) {
-        reply_t->error = newSVpvf("%s", "event reinit failed");
-        return;
-    }
-    redisClusterAsyncDisconnect(self->acc);
-
-    if (event_base_dispatch(self->cluster_event_base) == -1) {
-        reply_t->error = newSVpvf("%s", "event_base_dispatch failed after forking");
-        return;
-    }
-    event_base_free(self->cluster_event_base);
-    self->cluster_event_base = NULL;
-
-    redisClusterAsyncFree(self->acc);
-    self->acc = NULL;
 }
 
 void run_cmd_impl(pTHX_ Redis__Cluster__Fast self, int argc, const char **argv, size_t *argvlen,
@@ -335,7 +334,7 @@ void Redis__Cluster__Fast_run_cmd(pTHX_ Redis__Cluster__Fast self, int argc, con
 
     if (self->pid != getpid()) {
         DEBUG_MSG("%s", "pid changed");
-        disconnect(aTHX_ self, reply_t);
+        reply_t->error = Redis__Cluster__Fast_disconnect(aTHX_ self);
         if (reply_t->error) {
             return;
         }

--- a/src/Fast.xs
+++ b/src/Fast.xs
@@ -494,7 +494,9 @@ CODE:
         DEBUG_MSG("%s", "trying to free event_base");
         if ((self->pid == getpid()) || (event_reinit(self->cluster_event_base) == 0)){
             redisClusterAsyncDisconnect(self->acc);
-            event_base_dispatch(self->cluster_event_base);
+            if (event_base_dispatch(self->cluster_event_base) == -1) {
+                warn("event_base_dispatch failed.");
+            }
             event_base_free(self->cluster_event_base);
             self->cluster_event_base = NULL;
         } else {

--- a/src/Fast.xs
+++ b/src/Fast.xs
@@ -275,6 +275,8 @@ void disconnect(pTHX_ Redis__Cluster__Fast self, cmd_reply_context_t *reply_t) {
         reply_t->error = newSVpvf("%s", "event_base_dispatch failed after forking");
         return;
     }
+    event_base_free(self->cluster_event_base);
+    self->cluster_event_base = NULL;
 
     redisClusterAsyncFree(self->acc);
     self->acc = NULL;

--- a/src/Fast.xs
+++ b/src/Fast.xs
@@ -368,6 +368,11 @@ CODE:
 OUTPUT:
     RETVAL
 
+void
+__srandom(char *cls, unsigned int seed)
+CODE:
+    srandom(seed);
+
 int
 __set_debug(Redis::Cluster::Fast self, int val)
 CODE:

--- a/xt/07_simple_srandom.t
+++ b/xt/07_simple_srandom.t
@@ -1,0 +1,91 @@
+use strict;
+use warnings FATAL => 'all';
+use Test::More;
+use lib './xt/lib';
+use Test::Docker::RedisCluster qw/get_startup_nodes/;
+
+use Redis::Cluster::Fast;
+
+Redis::Cluster::Fast::srandom(1111);
+
+my $redis = Redis::Cluster::Fast->new(
+    startup_nodes => get_startup_nodes,
+);
+is $redis->ping, 'PONG';
+
+like $redis->CLUSTER_INFO(), qr/^cluster_state:ok/;
+
+my $res = $redis->eval(
+    "return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}",
+    2, '{key}1', '{key}2', 'first', 'second');
+is_deeply $res, [ '{key}1', '{key}2', 'first', 'second' ];
+
+is $redis->mset('{my}hoge', 'test', '{my}fuga', 'test2'), 'OK';
+
+my @res = $redis->mget('{my}hoge', '{my}fuga');
+is_deeply \@res, [ 'test', 'test2' ];
+
+$redis->hset('myhash', 'field1', 'Hello');
+$redis->hset('myhash', 'field2', 'ByeBye');
+is_deeply { $redis->hgetall('myhash') },
+    { field1 => 'Hello', field2 => 'ByeBye' };
+is_deeply scalar $redis->hgetall('myhash'),
+    [ 'field1', 'Hello', 'field2', 'ByeBye' ],
+    'Any client using RESP2 protocol can only see Redis hash as array';
+
+my $euro = "\x{20ac}";
+ok ord($euro) > 255, 'is a wide character';
+eval {
+    $redis->set('euro', $euro);
+};
+like $@, qr/^command sent is not an octet sequence in the native encoding \(Latin-1\)\./, 'can not convert to Latin-1';
+
+my $to_utf8 = my $to_latin1 = "test\x{80}";
+utf8::upgrade($to_utf8);
+utf8::downgrade($to_latin1);
+is $to_utf8, $to_latin1, 'in Perl, equal';
+$redis->del($to_latin1);
+$redis->set($to_utf8, 'unicode');
+is $redis->get($to_latin1), 'unicode', 'got value will be equal';
+
+eval {
+    Redis::Cluster::Fast->new(
+        startup_nodes => [
+            'localhost:1111corrupted'
+        ],
+    );
+};
+like $@, qr/^failed to add nodes: server port is incorrect/;
+
+{
+    my $redis_2 = Redis::Cluster::Fast->new(
+        startup_nodes => get_startup_nodes,
+    );
+    $redis_2->ping;
+
+    my $pid = fork;
+    if ($pid == 0) {
+        # child
+        # Do nothing
+        # call event_reinit at DESTROY
+        exit 0;
+    } else {
+        # parent
+        # Do nothing
+        waitpid($pid, 0);
+    }
+    is $redis_2->ping('PONG'), 'PONG';
+}
+
+for my $case (
+    [ undef, '^need startup_nodes' ],
+    [ [], '^need startup_nodes' ],
+    [ 'foo', '^Can\'t use string \("foo"\) as an ARRAY ref' ],
+) {
+    eval {
+        Redis::Cluster::Fast->new(startup_nodes => $case->[0]);
+    };
+    like $@, qr/$case->[1]/, 'startup_nodes validation';
+}
+
+done_testing;

--- a/xt/08_leak_srandom.t
+++ b/xt/08_leak_srandom.t
@@ -1,0 +1,61 @@
+use strict;
+use warnings FATAL => 'all';
+use Test::More;
+use lib './xt/lib';
+use Test::Docker::RedisCluster qw/get_startup_nodes/;
+
+use Redis::Cluster::Fast;
+use Test::LeakTrace;
+use Test::SharedFork;
+
+no_leaks_ok {
+    Redis::Cluster::Fast::srandom(1111);
+
+    my $redis = Redis::Cluster::Fast->new(
+        startup_nodes => get_startup_nodes,
+    );
+
+    eval {
+        # wide character
+        $redis->set('euro', "\x{20ac}");
+    };
+
+    $redis->ping;
+    $redis->CLUSTER_INFO();
+    $redis->eval(
+        "return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}",
+        2, '{key}1', '{key}2', 'first', 'second');
+    $redis->mset('{my}hoge', 'test', '{my}fuga', 'test2');
+    $redis->mget('{my}hoge', '{my}fuga');
+
+    eval {
+        Redis::Cluster::Fast->new(
+            startup_nodes => [
+                'localhost:1111corrupted'
+            ],
+        );
+    };
+} "No Memory leak";
+
+no_leaks_ok {
+    Redis::Cluster::Fast::srandom(2222);
+
+    my $redis = Redis::Cluster::Fast->new(
+        startup_nodes => get_startup_nodes,
+    );
+    $redis->del('test-leak');
+    my $pid = fork;
+    if ($pid == 0) {
+        # child
+        $redis->incr('test-leak');
+        exit 0;
+    } else {
+        # parent
+        $redis->incr('test-leak');
+        waitpid($pid, 0);
+    }
+
+    $redis->get('test-leak');
+} "No Memory leak - fork";
+
+done_testing;

--- a/xt/09_valgrind_srandom.t
+++ b/xt/09_valgrind_srandom.t
@@ -1,0 +1,80 @@
+use strict;
+use warnings FATAL => 'all';
+use lib './xt/lib';
+
+BEGIN {
+    use Test::More;
+    plan skip_all =>
+        'Skip tests using local Docker / Redis Cluster / Valgrind because AUTHOR_TESTING is not set' unless $ENV{AUTHOR_TESTING};
+};
+
+eval {
+    use Test::Valgrind (extra_supps => [ './xt/lib/memcheck-extra.supp' ]);
+};
+plan skip_all => 'Test::Valgrind is required to test your distribution with valgrind' if $@;
+
+use Test::Docker::RedisCluster qw/get_startup_nodes/; # Valgrind check this module too
+use Redis::Cluster::Fast;
+
+Redis::Cluster::Fast::srandom(1111);
+
+my $redis = Redis::Cluster::Fast->new(
+    startup_nodes => get_startup_nodes,
+    connect_timeout => 0.5,
+    command_timeout => 0.5,
+    max_retry_count => 10,
+);
+
+$redis->del('valgrind');
+$redis->set('valgrind', 123);
+
+eval {
+    # wide character
+    $redis->set('euro', "\x{20ac}");
+};
+
+my $pid = fork;
+if ($pid == 0) {
+    # child
+    $redis->incr('valgrind');
+    $redis->cluster_info;
+    exit 0;
+} else {
+    # parent
+    $redis->incr('valgrind');
+    $redis->cluster_info;
+    waitpid($pid, 0);
+}
+
+$redis->get('valgrind');
+$redis->cluster_info;
+
+eval {
+    Redis::Cluster::Fast->new(
+        startup_nodes => [
+            'localhost:1111corrupted'
+        ],
+    );
+};
+
+{
+    my $redis_2 = Redis::Cluster::Fast->new(
+        startup_nodes => get_startup_nodes,
+    );
+    $redis_2->ping;
+
+    my $pid = fork;
+    if ($pid == 0) {
+        # child
+        # Do nothing
+        # call event_reinit at DESTROY
+        exit 0;
+    } else {
+        # parent
+        # Do nothing
+        waitpid($pid, 0);
+    }
+    $redis_2->ping;
+}
+
+done_testing;

--- a/xt/10_timeout_srandom.t
+++ b/xt/10_timeout_srandom.t
@@ -1,0 +1,40 @@
+use strict;
+use warnings FATAL => 'all';
+use Test::More;
+use lib './xt/lib';
+use Test::Docker::RedisCluster qw/get_startup_nodes/;
+
+use Redis::Cluster::Fast;
+
+Redis::Cluster::Fast::srandom(1111);
+
+my $redis = Redis::Cluster::Fast->new(
+    startup_nodes => get_startup_nodes,
+    connect_timeout => 0.05,
+    command_timeout => 0.05,
+    max_retry_count => 3,
+);
+
+my $lua = <<EOF;
+local tmp = KEYS[1]
+
+redis.call("SET", tmp, "1")
+redis.call("EXPIRE", tmp, ARGV[1])
+
+for i = 0, ARGV[1] do
+    local is_exist = redis.call("EXISTS", tmp)
+    if is_exist == 0 then
+        break;
+    end
+end
+
+return {KEYS[1],ARGV[1],ARGV[2]}
+EOF
+
+eval {
+    # sleep 1 sec
+    $redis->eval($lua, 1, '{key}10', 1000000, 1);
+};
+like $@, qr/^\[eval\] Timeout/;
+
+done_testing;

--- a/xt/11_fork_srandom.t
+++ b/xt/11_fork_srandom.t
@@ -1,0 +1,37 @@
+use strict;
+use warnings FATAL => 'all';
+use Test::More;
+use lib './xt/lib';
+use Test::Docker::RedisCluster qw/get_startup_nodes/;
+
+use Redis::Cluster::Fast;
+use Test::SharedFork;
+
+Redis::Cluster::Fast::srandom(1111);
+
+my $redis = Redis::Cluster::Fast->new(
+    startup_nodes => get_startup_nodes,
+);
+$redis->mset('{my}hoge', 'test1', '{my}fuga', 'test2');
+$redis->mset('{my}foo', 'FOO', '{my}bar', 'BAR');
+$redis->del('test-fork');
+
+my $pid = fork;
+if ($pid == 0) {
+    # child
+    my $res = $redis->mget('{my}hoge', '{my}fuga');
+    is_deeply $res, [ 'test1', 'test2' ];
+    $redis->incr('test-fork');
+    exit 0;
+}
+else {
+    # parent
+    my $res = $redis->mget('{my}foo', '{my}bar');
+    is_deeply $res, [ 'FOO', 'BAR' ];
+    $redis->incr('test-fork');
+    waitpid($pid, 0);
+}
+
+is $redis->get('test-fork'), 2;
+
+done_testing;


### PR DESCRIPTION
Replace legacy `redisClusterConnect2()` API with `redisClusterAsyncConnect2()` API.
This change will result in random node selection when issuing commands to retrieve topology, eliminating biases in node selection.