### PR TITLE
Add pipeline support with wait methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,16 +180,12 @@ The return value can be either 0 for normal, 1 for no callbacks remained, or -1 
 Normally you should not call `disconnect` manually.
 If you want to call fork(), `disconnect` should be call before fork().
 
-The return value is an error.
-
 It will be blocked until all unexecuted commands are executed, and then it will disconnect.
 
 ## connect()
 
 Normally you should not call `connect` manually.
 If you want to call fork(), `connect` should be call after fork().
-
-The return value is an error.
 
 # LICENSE
 

--- a/README.md
+++ b/README.md
@@ -163,12 +163,12 @@ You cannot call any client methods inside the callback.
         # some operations...
     });
 
-## wait\_one\_response
+## wait\_one\_response()
 
 If there are any unexcuted callbacks, it will block until at least one is executed.
 The return value can be either 0 for normal, 1 for no callbacks executed, or -1 for other errors.
 
-## wait\_all\_response
+## wait\_all\_response()
 
 If there are any unexcuted callbacks, it will block until all of them are executed.
 The return value can be either 0 for normal, 1 for no callbacks executed, or -1 for other errors.

--- a/README.md
+++ b/README.md
@@ -166,12 +166,12 @@ If there are unexecuted callbacks, the command may be sent from both the parent 
 ## wait\_one\_response()
 
 If there are any unexcuted callbacks, it will block until at least one is executed.
-The return value can be either 0 for normal, 1 for no callbacks executed, or -1 for other errors.
+The return value can be either 0 for normal, 1 for no callbacks remained, or -1 for other errors.
 
 ## wait\_all\_responses()
 
 If there are any unexcuted callbacks, it will block until all of them are executed.
-The return value can be either 0 for normal, 1 for no callbacks executed, or -1 for other errors.
+The return value can be either 0 for normal, 1 for no callbacks remained, or -1 for other errors.
 
 ## disconnect()
 

--- a/README.md
+++ b/README.md
@@ -148,15 +148,15 @@ The command can also be expressed by concatenating the subcommands with undersco
 Commands issued to the same node are sent and received in pipeline mode.
 In pipeline mode, commands are not sent to Redis until `wait_one_response` or `wait_all_responses` is issued.
 
-DO NOT execute fork() without issuing `wait_one_response` or `wait_all_responses` after issuing a command in pipeline mode.
-If there are unexecuted callbacks, the command will be sent to Redis from both the parent process and the child process.
-
 The callback is executed with two arguments.
 The first is the result of the command, and the second is the error message.
 `result` will be a scalar value or an array reference, and `$error` will be an undefined value if no errors occur.
 Also, `error` may contain an error returned from Redis or an error that occurred on the client (e.g. Timeout).
 
 You cannot call any client methods inside the callback.
+
+Do not execute fork() without issuing `wait_one_response` or `wait_all_responses` and `disconnect` after issuing a command in pipeline mode.
+If there are unexecuted callbacks, the command may be sent from both the parent process and the child process.
 
     $redis->get('test', sub {
         my ($result, $error) = @_;
@@ -179,6 +179,8 @@ Normally you should not call `disconnect` manually.
 If you want to call fork(), `disconnect` should be call before fork().
 
 The return value is an error.
+
+It will be blocked until all unexecuted commands are executed, and then it will disconnect.
 
 ## connect()
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ The command can also be expressed by concatenating the subcommands with undersco
 
 It does not support (Sharded) Pub/Sub family of commands and should not be run.
 
-Please issue `disconnect` in advance if you are going to excute fork() after issuing a command.
+It is recommended to issue `disconnect` in advance just to be safe when executing fork() after issuing the command.
 
 ## &lt;command>(@args, sub {})
 

--- a/README.md
+++ b/README.md
@@ -146,9 +146,9 @@ To run a Redis command in pipeline with arguments and a callback.
 The command can also be expressed by concatenating the subcommands with underscores.
 
 Commands issued to the same node are sent and received in pipeline mode.
-In pipeline mode, commands are not sent to Redis until `wait_one_response` or `wait_all_response` is issued.
+In pipeline mode, commands are not sent to Redis until `wait_one_response` or `wait_all_responses` is issued.
 
-DO NOT execute fork() without issuing `wait_one_response` or `wait_all_response` after issuing a command in pipeline mode.
+DO NOT execute fork() without issuing `wait_one_response` or `wait_all_responses` after issuing a command in pipeline mode.
 If there are unexecuted callbacks, the command will be sent to Redis from both the parent process and the child process.
 
 The callback is executed with two arguments.
@@ -168,7 +168,7 @@ You cannot call any client methods inside the callback.
 If there are any unexcuted callbacks, it will block until at least one is executed.
 The return value can be either 0 for normal, 1 for no callbacks executed, or -1 for other errors.
 
-## wait\_all\_response()
+## wait\_all\_responses()
 
 If there are any unexcuted callbacks, it will block until all of them are executed.
 The return value can be either 0 for normal, 1 for no callbacks executed, or -1 for other errors.

--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ The command can also be expressed by concatenating the subcommands with undersco
 Commands issued to the same node are sent and received in pipeline mode.
 In pipeline mode, commands are not sent to Redis until `wait_one_response` or `wait_all_response` is issued.
 
+DO NOT execute fork() without issuing `wait_one_response` or `wait_all_response` after issuing a command in pipeline mode.
+If there are unexecuted callbacks, the command will be sent to Redis from both the parent process and the child process.
+
 The callback is executed with two arguments.
 The first is the result of the command, and the second is the error message.
 `result` will be a scalar value or an array reference, and `$error` will be an undefined value if no errors occur.

--- a/README.md
+++ b/README.md
@@ -168,12 +168,12 @@ do not execute fork() without issuing `disconnect` if all callbacks are not exec
 ## wait\_one\_response()
 
 If there are any unexcuted callbacks, it will block until at least one is executed.
-The return value can be either 0 for normal, 1 for no callbacks remained, or -1 for other errors.
+The return value can be either 1 for success, 0 for no callbacks remained, or undef for other errors.
 
 ## wait\_all\_responses()
 
 If there are any unexcuted callbacks, it will block until all of them are executed.
-The return value can be either 0 for normal, 1 for no callbacks remained, or -1 for other errors.
+The return value can be either 1 for success, 0 for no callbacks remained, or undef for other errors.
 
 ## disconnect()
 

--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ In pipeline mode, commands are not sent to Redis until `wait_one_response` or `w
 
 The callback is executed with two arguments.
 The first is the result of the command, and the second is the error message.
-`result` will be a scalar value or an array reference, and `$error` will be an undefined value if no errors occur.
-Also, `error` may contain an error returned from Redis or an error that occurred on the client (e.g. Timeout).
+`$result` will be a scalar value or an array reference, and `$error` will be an undefined value if no errors occur.
+Also, `$error` may contain an error returned from Redis or an error that occurred on the client (e.g. Timeout).
 
 You cannot call any client methods inside the callback.
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,20 @@ The return value can be either 0 for normal, 1 for no callbacks executed, or -1 
 If there are any unexcuted callbacks, it will block until all of them are executed.
 The return value can be either 0 for normal, 1 for no callbacks executed, or -1 for other errors.
 
+## disconnect()
+
+Normally you should not call `disconnect` manually.
+If you want to call fork(), `disconnect` should be call before fork().
+
+The return value is an error.
+
+## connect()
+
+Normally you should not call `connect` manually.
+If you want to call fork(), `connect` should be call after fork().
+
+The return value is an error.
+
 # LICENSE
 
 Copyright (C) plainbanana.

--- a/README.md
+++ b/README.md
@@ -139,6 +139,37 @@ The command can also be expressed by concatenating the subcommands with undersco
 
 It does not support (Sharded) Pub/Sub family of commands and should not be run.
 
+## &lt;command>(@args, sub {})
+
+To run a Redis command in pipeline with arguments and a callback.
+
+The command can also be expressed by concatenating the subcommands with underscores.
+
+Commands issued to the same node are sent and received in pipeline mode.
+In pipeline mode, commands are not sent to Redis until `wait_one_response` or `wait_all_response` is issued.
+
+The callback is executed with two arguments.
+The first is the result of the command, and the second is the error message.
+`result` will be a scalar value or an array reference, and `$error` will be an undefined value if no errors occur.
+Also, `error` may contain an error returned from Redis or an error that occurred on the client (e.g. Timeout).
+
+You cannot call any client methods inside the callback.
+
+    $redis->get('test', sub {
+        my ($result, $error) = @_;
+        # some operations...
+    });
+
+## wait\_one\_response
+
+If there are any unexcuted callbacks, it will block until at least one is executed.
+The return value can be either 0 for normal, 1 for no callbacks executed, or -1 for other errors.
+
+## wait\_all\_response
+
+If there are any unexcuted callbacks, it will block until all of them are executed.
+The return value can be either 0 for normal, 1 for no callbacks executed, or -1 for other errors.
+
 # LICENSE
 
 Copyright (C) plainbanana.

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ The command can also be expressed by concatenating the subcommands with undersco
 
 It does not support (Sharded) Pub/Sub family of commands and should not be run.
 
+Please issue `disconnect` in advance if you are going to excute fork() after issuing a command.
+
 ## &lt;command>(@args, sub {})
 
 To run a Redis command in pipeline with arguments and a callback.
@@ -155,8 +157,8 @@ Also, `$error` may contain an error returned from Redis or an error that occurre
 
 You cannot call any client methods inside the callback.
 
-Do not execute fork() without issuing `wait_one_response` or `wait_all_responses` and `disconnect` after issuing a command in pipeline mode.
-If there are unexecuted callbacks, the command may be sent from both the parent process and the child process.
+After issuing a command in pipeline mode,
+do not execute fork() without issuing `disconnect` if all callbacks are not executed completely.
 
     $redis->get('test', sub {
         my ($result, $error) = @_;

--- a/lib/Redis/Cluster/Fast.pm
+++ b/lib/Redis/Cluster/Fast.pm
@@ -69,6 +69,18 @@ sub wait_all_response {
     $self->__wait_all_response();
 }
 
+sub disconnect {
+    my $self = shift;
+    $self->__disconnect();
+}
+
+sub connect {
+    my $self = shift;
+    my $error = $self->__connect();
+    return $error if $error;
+    $self->__wait_until_event_ready();
+}
+
 ### Deal with common, general case, Redis commands
 our $AUTOLOAD;
 
@@ -283,6 +295,20 @@ The return value can be either 0 for normal, 1 for no callbacks executed, or -1 
 
 If there are any unexcuted callbacks, it will block until all of them are executed.
 The return value can be either 0 for normal, 1 for no callbacks executed, or -1 for other errors.
+
+=head2 disconnect()
+
+Normally you should not call C<disconnect> manually.
+If you want to call fork(), C<disconnect> should be call before fork().
+
+The return value is an error.
+
+=head2 connect()
+
+Normally you should not call C<connect> manually.
+If you want to call fork(), C<connect> should be call after fork().
+
+The return value is an error.
 
 =head1 LICENSE
 

--- a/lib/Redis/Cluster/Fast.pm
+++ b/lib/Redis/Cluster/Fast.pm
@@ -262,6 +262,8 @@ The command can also be expressed by concatenating the subcommands with undersco
 
 It does not support (Sharded) Pub/Sub family of commands and should not be run.
 
+Please issue C<disconnect> in advance if you are going to excute fork() after issuing a command.
+
 =head2 <command>(@args, sub {})
 
 To run a Redis command in pipeline with arguments and a callback.
@@ -278,8 +280,8 @@ Also, C<$error> may contain an error returned from Redis or an error that occurr
 
 You cannot call any client methods inside the callback.
 
-Do not execute fork() without issuing C<wait_one_response> or C<wait_all_responses> and C<disconnect> after issuing a command in pipeline mode.
-If there are unexecuted callbacks, the command may be sent from both the parent process and the child process.
+After issuing a command in pipeline mode,
+do not execute fork() without issuing C<disconnect> if all callbacks are not executed completely.
 
     $redis->get('test', sub {
         my ($result, $error) = @_;

--- a/lib/Redis/Cluster/Fast.pm
+++ b/lib/Redis/Cluster/Fast.pm
@@ -259,6 +259,9 @@ The command can also be expressed by concatenating the subcommands with undersco
 Commands issued to the same node are sent and received in pipeline mode.
 In pipeline mode, commands are not sent to Redis until C<wait_one_response> or C<wait_all_response> is issued.
 
+DO NOT execute fork() without issuing C<wait_one_response> or C<wait_all_response> after issuing a command in pipeline mode.
+If there are unexecuted callbacks, the command will be sent to Redis from both the parent process and the child process.
+
 The callback is executed with two arguments.
 The first is the result of the command, and the second is the error message.
 C<result> will be a scalar value or an array reference, and C<$error> will be an undefined value if no errors occur.

--- a/lib/Redis/Cluster/Fast.pm
+++ b/lib/Redis/Cluster/Fast.pm
@@ -61,12 +61,16 @@ sub new {
 
 sub wait_one_response {
     my $self = shift;
-    $self->__wait_one_response();
+    my $result = $self->__wait_one_response();
+    return undef if $result == -1;
+    return $result;
 }
 
 sub wait_all_responses {
     my $self = shift;
-    $self->__wait_all_responses();
+    my $result = $self->__wait_all_responses();
+    return undef if $result == -1;
+    return $result;
 }
 
 sub disconnect {
@@ -295,12 +299,12 @@ do not execute fork() without issuing C<disconnect> if all callbacks are not exe
 =head2 wait_one_response()
 
 If there are any unexcuted callbacks, it will block until at least one is executed.
-The return value can be either 0 for normal, 1 for no callbacks remained, or -1 for other errors.
+The return value can be either 1 for success, 0 for no callbacks remained, or undef for other errors.
 
 =head2 wait_all_responses()
 
 If there are any unexcuted callbacks, it will block until all of them are executed.
-The return value can be either 0 for normal, 1 for no callbacks remained, or -1 for other errors.
+The return value can be either 1 for success, 0 for no callbacks remained, or undef for other errors.
 
 =head2 disconnect()
 

--- a/lib/Redis/Cluster/Fast.pm
+++ b/lib/Redis/Cluster/Fast.pm
@@ -271,15 +271,15 @@ The command can also be expressed by concatenating the subcommands with undersco
 Commands issued to the same node are sent and received in pipeline mode.
 In pipeline mode, commands are not sent to Redis until C<wait_one_response> or C<wait_all_responses> is issued.
 
-DO NOT execute fork() without issuing C<wait_one_response> or C<wait_all_responses> after issuing a command in pipeline mode.
-If there are unexecuted callbacks, the command will be sent to Redis from both the parent process and the child process.
-
 The callback is executed with two arguments.
 The first is the result of the command, and the second is the error message.
 C<result> will be a scalar value or an array reference, and C<$error> will be an undefined value if no errors occur.
 Also, C<error> may contain an error returned from Redis or an error that occurred on the client (e.g. Timeout).
 
 You cannot call any client methods inside the callback.
+
+Do not execute fork() without issuing C<wait_one_response> or C<wait_all_responses> and C<disconnect> after issuing a command in pipeline mode.
+If there are unexecuted callbacks, the command may be sent from both the parent process and the child process.
 
     $redis->get('test', sub {
         my ($result, $error) = @_;
@@ -302,6 +302,8 @@ Normally you should not call C<disconnect> manually.
 If you want to call fork(), C<disconnect> should be call before fork().
 
 The return value is an error.
+
+It will be blocked until all unexecuted commands are executed, and then it will disconnect.
 
 =head2 connect()
 

--- a/lib/Redis/Cluster/Fast.pm
+++ b/lib/Redis/Cluster/Fast.pm
@@ -289,12 +289,12 @@ If there are unexecuted callbacks, the command may be sent from both the parent 
 =head2 wait_one_response()
 
 If there are any unexcuted callbacks, it will block until at least one is executed.
-The return value can be either 0 for normal, 1 for no callbacks executed, or -1 for other errors.
+The return value can be either 0 for normal, 1 for no callbacks remained, or -1 for other errors.
 
 =head2 wait_all_responses()
 
 If there are any unexcuted callbacks, it will block until all of them are executed.
-The return value can be either 0 for normal, 1 for no callbacks executed, or -1 for other errors.
+The return value can be either 0 for normal, 1 for no callbacks remained, or -1 for other errors.
 
 =head2 disconnect()
 

--- a/lib/Redis/Cluster/Fast.pm
+++ b/lib/Redis/Cluster/Fast.pm
@@ -64,9 +64,9 @@ sub wait_one_response {
     $self->__wait_one_response();
 }
 
-sub wait_all_response {
+sub wait_all_responses {
     my $self = shift;
-    $self->__wait_all_response();
+    $self->__wait_all_responses();
 }
 
 sub disconnect {
@@ -269,9 +269,9 @@ To run a Redis command in pipeline with arguments and a callback.
 The command can also be expressed by concatenating the subcommands with underscores.
 
 Commands issued to the same node are sent and received in pipeline mode.
-In pipeline mode, commands are not sent to Redis until C<wait_one_response> or C<wait_all_response> is issued.
+In pipeline mode, commands are not sent to Redis until C<wait_one_response> or C<wait_all_responses> is issued.
 
-DO NOT execute fork() without issuing C<wait_one_response> or C<wait_all_response> after issuing a command in pipeline mode.
+DO NOT execute fork() without issuing C<wait_one_response> or C<wait_all_responses> after issuing a command in pipeline mode.
 If there are unexecuted callbacks, the command will be sent to Redis from both the parent process and the child process.
 
 The callback is executed with two arguments.
@@ -291,7 +291,7 @@ You cannot call any client methods inside the callback.
 If there are any unexcuted callbacks, it will block until at least one is executed.
 The return value can be either 0 for normal, 1 for no callbacks executed, or -1 for other errors.
 
-=head2 wait_all_response()
+=head2 wait_all_responses()
 
 If there are any unexcuted callbacks, it will block until all of them are executed.
 The return value can be either 0 for normal, 1 for no callbacks executed, or -1 for other errors.

--- a/lib/Redis/Cluster/Fast.pm
+++ b/lib/Redis/Cluster/Fast.pm
@@ -266,7 +266,7 @@ The command can also be expressed by concatenating the subcommands with undersco
 
 It does not support (Sharded) Pub/Sub family of commands and should not be run.
 
-Please issue C<disconnect> in advance if you are going to excute fork() after issuing a command.
+It is recommended to issue C<disconnect> in advance just to be safe when executing fork() after issuing the command.
 
 =head2 <command>(@args, sub {})
 

--- a/lib/Redis/Cluster/Fast.pm
+++ b/lib/Redis/Cluster/Fast.pm
@@ -71,14 +71,16 @@ sub wait_all_responses {
 
 sub disconnect {
     my $self = shift;
-    $self->__disconnect();
+    my $error = $self->__disconnect();
+    croak $error if $error;
 }
 
 sub connect {
     my $self = shift;
     my $error = $self->__connect();
-    return $error if $error;
-    $self->__wait_until_event_ready();
+    croak $error if $error;
+    $error = $self->__wait_until_event_ready();
+    croak $error if $error;
 }
 
 ### Deal with common, general case, Redis commands
@@ -303,16 +305,12 @@ The return value can be either 0 for normal, 1 for no callbacks remained, or -1 
 Normally you should not call C<disconnect> manually.
 If you want to call fork(), C<disconnect> should be call before fork().
 
-The return value is an error.
-
 It will be blocked until all unexecuted commands are executed, and then it will disconnect.
 
 =head2 connect()
 
 Normally you should not call C<connect> manually.
 If you want to call fork(), C<connect> should be call after fork().
-
-The return value is an error.
 
 =head1 LICENSE
 

--- a/lib/Redis/Cluster/Fast.pm
+++ b/lib/Redis/Cluster/Fast.pm
@@ -95,6 +95,8 @@ sub AUTOLOAD {
         my $self = shift;
         my @arguments = @_;
         for my $index (0 .. $#arguments) {
+            next if ref $arguments[$index] eq 'CODE';
+
             utf8::downgrade($arguments[$index], 1)
                 or croak 'command sent is not an octet sequence in the native encoding (Latin-1).';
         }

--- a/lib/Redis/Cluster/Fast.pm
+++ b/lib/Redis/Cluster/Fast.pm
@@ -286,12 +286,12 @@ You cannot call any client methods inside the callback.
         # some operations...
     });
 
-=head2 wait_one_response
+=head2 wait_one_response()
 
 If there are any unexcuted callbacks, it will block until at least one is executed.
 The return value can be either 0 for normal, 1 for no callbacks executed, or -1 for other errors.
 
-=head2 wait_all_response
+=head2 wait_all_response()
 
 If there are any unexcuted callbacks, it will block until all of them are executed.
 The return value can be either 0 for normal, 1 for no callbacks executed, or -1 for other errors.

--- a/lib/Redis/Cluster/Fast.pm
+++ b/lib/Redis/Cluster/Fast.pm
@@ -273,8 +273,8 @@ In pipeline mode, commands are not sent to Redis until C<wait_one_response> or C
 
 The callback is executed with two arguments.
 The first is the result of the command, and the second is the error message.
-C<result> will be a scalar value or an array reference, and C<$error> will be an undefined value if no errors occur.
-Also, C<error> may contain an error returned from Redis or an error that occurred on the client (e.g. Timeout).
+C<$result> will be a scalar value or an array reference, and C<$error> will be an undefined value if no errors occur.
+Also, C<$error> may contain an error returned from Redis or an error that occurred on the client (e.g. Timeout).
 
 You cannot call any client methods inside the callback.
 

--- a/src/Fast.xs
+++ b/src/Fast.xs
@@ -243,6 +243,9 @@ void eventCallback(const redisClusterContext *cc, int event, void *privdata) {
 
 SV *Redis__Cluster__Fast_connect(pTHX_ Redis__Cluster__Fast self) {
     DEBUG_MSG("%s", "start connect");
+    if (self->cluster_event_base && self->acc) {
+        return newSVpvf("%s", "already connected");
+    }
 
     self->pipeline_callback_remain = 0;
     self->pid = getpid();

--- a/src/Fast.xs
+++ b/src/Fast.xs
@@ -617,6 +617,16 @@ OUTPUT:
     RETVAL
 
 SV*
+__disconnect(Redis::Cluster::Fast self)
+CODE:
+    RETVAL = Redis__Cluster__Fast_disconnect(aTHX_ self);
+    if (RETVAL == NULL) {
+        RETVAL = &PL_sv_undef;
+    }
+OUTPUT:
+    RETVAL
+
+SV*
 __wait_until_event_ready(Redis::Cluster::Fast self)
 CODE:
     RETVAL = Redis__Cluster__Fast_wait_until_event_ready(aTHX_ self);

--- a/src/Fast.xs
+++ b/src/Fast.xs
@@ -466,9 +466,6 @@ int Redis__Cluster__Fast_wait_one_response(pTHX_ Redis__Cluster__Fast self) {
     if (callback_remain_current <= 0) {
         return 1;
     }
-    if (self->pid != getpid()) {
-        return -1;
-    }
     while (self->pipeline_callback_remain == callback_remain_current) {
         DEBUG_EVENT_BASE();
         event_loop_error = event_base_loop(self->cluster_event_base, EVLOOP_ONCE);
@@ -483,9 +480,6 @@ int Redis__Cluster__Fast_wait_all_responses(pTHX_ Redis__Cluster__Fast self) {
     int event_loop_error;
     if (self->pipeline_callback_remain <= 0) {
         return 1;
-    }
-    if (self->pid != getpid()) {
-        return -1;
     }
     while (self->pipeline_callback_remain > 0) {
         DEBUG_EVENT_BASE();

--- a/src/Fast.xs
+++ b/src/Fast.xs
@@ -459,6 +459,9 @@ int Redis__Cluster__Fast_wait_one_response(pTHX_ Redis__Cluster__Fast self) {
     if (callback_remain_current <= 0) {
         return 1;
     }
+    if (self->pid != getpid()) {
+        return -1;
+    }
     while (self->pipeline_callback_remain == callback_remain_current) {
         DEBUG_EVENT_BASE();
         event_loop_error = event_base_loop(self->cluster_event_base, EVLOOP_ONCE);
@@ -473,6 +476,9 @@ int Redis__Cluster__Fast_wait_all_response(pTHX_ Redis__Cluster__Fast self) {
     int event_loop_error;
     if (self->pipeline_callback_remain <= 0) {
         return 1;
+    }
+    if (self->pid != getpid()) {
+        return -1;
     }
     while (self->pipeline_callback_remain > 0) {
         DEBUG_EVENT_BASE();

--- a/src/Fast.xs
+++ b/src/Fast.xs
@@ -244,6 +244,7 @@ void eventCallback(const redisClusterContext *cc, int event, void *privdata) {
 SV *Redis__Cluster__Fast_connect(pTHX_ Redis__Cluster__Fast self) {
     DEBUG_MSG("%s", "start connect");
 
+    self->pipeline_callback_remain = 0;
     self->pid = getpid();
 
     self->acc = redisClusterAsyncContextInit();

--- a/src/Fast.xs
+++ b/src/Fast.xs
@@ -287,6 +287,10 @@ SV *Redis__Cluster__Fast_connect(pTHX_ Redis__Cluster__Fast self) {
 }
 
 SV *Redis__Cluster__Fast_disconnect(pTHX_ Redis__Cluster__Fast self) {
+    if (self->cluster_event_base == NULL && self->acc == NULL) {
+        return NULL;
+    }
+
     if (event_reinit(self->cluster_event_base) != 0) {
         return newSVpvf("%s", "event reinit failed");
     }

--- a/src/Fast.xs
+++ b/src/Fast.xs
@@ -464,7 +464,7 @@ int Redis__Cluster__Fast_wait_one_response(pTHX_ Redis__Cluster__Fast self) {
     int event_loop_error;
     int64_t callback_remain_current = self->pipeline_callback_remain;
     if (callback_remain_current <= 0) {
-        return 1;
+        return 0;
     }
     while (self->pipeline_callback_remain == callback_remain_current) {
         DEBUG_EVENT_BASE();
@@ -473,13 +473,13 @@ int Redis__Cluster__Fast_wait_one_response(pTHX_ Redis__Cluster__Fast self) {
             return -1;
         }
     }
-    return 0;
+    return 1;
 }
 
 int Redis__Cluster__Fast_wait_all_responses(pTHX_ Redis__Cluster__Fast self) {
     int event_loop_error;
     if (self->pipeline_callback_remain <= 0) {
-        return 1;
+        return 0;
     }
     while (self->pipeline_callback_remain > 0) {
         DEBUG_EVENT_BASE();
@@ -488,7 +488,7 @@ int Redis__Cluster__Fast_wait_all_responses(pTHX_ Redis__Cluster__Fast self) {
             return -1;
         }
     }
-    return 0;
+    return 1;
 }
 
 void Redis__Cluster__Fast_run_cmd(pTHX_ Redis__Cluster__Fast self, int argc, const char **argv, size_t *argvlen,

--- a/src/Fast.xs
+++ b/src/Fast.xs
@@ -472,7 +472,7 @@ int Redis__Cluster__Fast_wait_one_response(pTHX_ Redis__Cluster__Fast self) {
     return 0;
 }
 
-int Redis__Cluster__Fast_wait_all_response(pTHX_ Redis__Cluster__Fast self) {
+int Redis__Cluster__Fast_wait_all_responses(pTHX_ Redis__Cluster__Fast self) {
     int event_loop_error;
     if (self->pipeline_callback_remain <= 0) {
         return 1;
@@ -688,9 +688,9 @@ OUTPUT:
     RETVAL
 
 int
-__wait_all_response(Redis::Cluster::Fast self)
+__wait_all_responses(Redis::Cluster::Fast self)
 CODE:
-    RETVAL = Redis__Cluster__Fast_wait_all_response(aTHX_ self);
+    RETVAL = Redis__Cluster__Fast_wait_all_responses(aTHX_ self);
 OUTPUT:
     RETVAL
 

--- a/xt/02_leak.t
+++ b/xt/02_leak.t
@@ -69,9 +69,9 @@ no_leaks_ok {
     $redis->get('pipeline', sub {
         my ($result, $error) = @_;
     });
-    $redis->wait_all_response;
-    $redis->wait_all_response;
-} "No Memory leak - pipeline wait_all_response";
+    $redis->wait_all_responses;
+    $redis->wait_all_responses;
+} "No Memory leak - pipeline wait_all_responses";
 
 no_leaks_ok {
     my $redis = Redis::Cluster::Fast->new(

--- a/xt/02_leak.t
+++ b/xt/02_leak.t
@@ -54,4 +54,42 @@ no_leaks_ok {
     $redis->get('test-leak');
 } "No Memory leak - fork";
 
+no_leaks_ok {
+    my $redis = Redis::Cluster::Fast->new(
+        startup_nodes => get_startup_nodes,
+    );
+    $redis->del('pipeline');
+
+    $redis->set('pipeline', 12345, sub {
+        my ($result, $error) = @_;
+    });
+    $redis->get('pipeline', sub {
+        my ($result, $error) = @_;
+    });
+    $redis->get('pipeline', sub {
+        my ($result, $error) = @_;
+    });
+    $redis->wait_all_response;
+    $redis->wait_all_response;
+} "No Memory leak - pipeline wait_all_response";
+
+no_leaks_ok {
+    my $redis = Redis::Cluster::Fast->new(
+        startup_nodes => get_startup_nodes,
+    );
+    $redis->del('pipeline');
+
+    $redis->set('pipeline', 12345, sub {
+        my ($result, $error) = @_;
+    });
+    $redis->get('pipeline', sub {
+        my ($result, $error) = @_;
+    });
+    $redis->get('pipeline', sub {
+        my ($result, $error) = @_;
+    });
+    $redis->wait_one_response;
+    $redis->wait_one_response;
+} "No Memory leak - pipeline wait_one_response";
+
 done_testing;

--- a/xt/03_fork.t
+++ b/xt/03_fork.t
@@ -31,9 +31,19 @@ if ($pid == 0) {
 
 is $redis->get('test-fork'), 2;
 
+my $res;
+$redis->mget('{my}hoge', '{my}fuga', sub {
+    my ($result, $error) = @_;
+    $res = $result;
+});
+$redis->wait_all_responses;
+is_deeply $res, [ 'test1', 'test2' ];
+$redis->disconnect;
+
 $pid = fork;
 if ($pid == 0) {
     # child
+    $redis->connect;
     my $res;
     $redis->mget('{my}hoge', '{my}fuga', sub {
         my ($result, $error) = @_;
@@ -44,6 +54,7 @@ if ($pid == 0) {
     exit 0;
 } else {
     # parent
+    $redis->connect;
     my $res;
     $redis->mget('{my}foo', '{my}bar', sub {
         my ($result, $error) = @_;

--- a/xt/03_fork.t
+++ b/xt/03_fork.t
@@ -36,7 +36,7 @@ $redis->mget('{my}hoge', '{my}fuga', sub {
     my ($result, $error) = @_;
     $res = $result;
 });
-$redis->wait_all_responses;
+ok $redis->wait_all_responses;
 is_deeply $res, [ 'test1', 'test2' ];
 $redis->disconnect;
 
@@ -49,7 +49,7 @@ if ($pid == 0) {
         my ($result, $error) = @_;
         $res = $result;
     });
-    $redis->wait_all_responses;
+    ok $redis->wait_all_responses;
     is_deeply $res, [ 'test1', 'test2' ];
     exit 0;
 } else {
@@ -60,7 +60,7 @@ if ($pid == 0) {
         my ($result, $error) = @_;
         $res = $result;
     });
-    $redis->wait_all_responses;
+    ok $redis->wait_all_responses;
     is_deeply $res, [ 'FOO', 'BAR' ];
     waitpid($pid, 0);
 }

--- a/xt/03_fork.t
+++ b/xt/03_fork.t
@@ -39,7 +39,7 @@ if ($pid == 0) {
         my ($result, $error) = @_;
         $res = $result;
     });
-    $redis->wait_all_response;
+    $redis->wait_all_responses;
     is_deeply $res, [ 'test1', 'test2' ];
     exit 0;
 } else {
@@ -49,7 +49,7 @@ if ($pid == 0) {
         my ($result, $error) = @_;
         $res = $result;
     });
-    $redis->wait_all_response;
+    $redis->wait_all_responses;
     is_deeply $res, [ 'FOO', 'BAR' ];
     waitpid($pid, 0);
 }

--- a/xt/03_fork.t
+++ b/xt/03_fork.t
@@ -21,8 +21,7 @@ if ($pid == 0) {
     is_deeply $res, [ 'test1', 'test2' ];
     $redis->incr('test-fork');
     exit 0;
-}
-else {
+} else {
     # parent
     my $res = $redis->mget('{my}foo', '{my}bar');
     is_deeply $res, [ 'FOO', 'BAR' ];
@@ -31,5 +30,28 @@ else {
 }
 
 is $redis->get('test-fork'), 2;
+
+$pid = fork;
+if ($pid == 0) {
+    # child
+    my $res;
+    $redis->mget('{my}hoge', '{my}fuga', sub {
+        my ($result, $error) = @_;
+        $res = $result;
+    });
+    $redis->wait_all_response;
+    is_deeply $res, [ 'test1', 'test2' ];
+    exit 0;
+} else {
+    # parent
+    my $res;
+    $redis->mget('{my}foo', '{my}bar', sub {
+        my ($result, $error) = @_;
+        $res = $result;
+    });
+    $redis->wait_all_response;
+    is_deeply $res, [ 'FOO', 'BAR' ];
+    waitpid($pid, 0);
+}
 
 done_testing;

--- a/xt/05_valgrind.t
+++ b/xt/05_valgrind.t
@@ -75,4 +75,42 @@ eval {
     $redis_2->ping;
 }
 
+{
+    my $redis = Redis::Cluster::Fast->new(
+        startup_nodes => get_startup_nodes,
+    );
+    $redis->del('pipeline');
+
+    $redis->set('pipeline', 12345, sub {
+        my ($result, $error) = @_;
+    });
+    $redis->get('pipeline', sub {
+        my ($result, $error) = @_;
+    });
+    $redis->get('pipeline', sub {
+        my ($result, $error) = @_;
+    });
+    $redis->wait_all_response;
+    $redis->wait_all_response;
+}
+
+{
+    my $redis = Redis::Cluster::Fast->new(
+        startup_nodes => get_startup_nodes,
+    );
+    $redis->del('pipeline');
+
+    $redis->set('pipeline', 12345, sub {
+        my ($result, $error) = @_;
+    });
+    $redis->get('pipeline', sub {
+        my ($result, $error) = @_;
+    });
+    $redis->get('pipeline', sub {
+        my ($result, $error) = @_;
+    });
+    $redis->wait_one_response;
+    $redis->wait_one_response;
+}
+
 done_testing;

--- a/xt/05_valgrind.t
+++ b/xt/05_valgrind.t
@@ -90,8 +90,8 @@ eval {
     $redis->get('pipeline', sub {
         my ($result, $error) = @_;
     });
-    $redis->wait_all_responses;
-    $redis->wait_all_responses;
+    ok $redis->wait_all_responses;
+    is $redis->wait_all_responses, 0;
 }
 
 {
@@ -109,8 +109,8 @@ eval {
     $redis->get('pipeline', sub {
         my ($result, $error) = @_;
     });
-    $redis->wait_one_response;
-    $redis->wait_one_response;
+    ok $redis->wait_one_response;
+    is $redis->wait_one_response, 0;
 }
 
 done_testing;

--- a/xt/05_valgrind.t
+++ b/xt/05_valgrind.t
@@ -90,8 +90,8 @@ eval {
     $redis->get('pipeline', sub {
         my ($result, $error) = @_;
     });
-    $redis->wait_all_response;
-    $redis->wait_all_response;
+    $redis->wait_all_responses;
+    $redis->wait_all_responses;
 }
 
 {

--- a/xt/08_leak_srandom.t
+++ b/xt/08_leak_srandom.t
@@ -58,4 +58,42 @@ no_leaks_ok {
     $redis->get('test-leak');
 } "No Memory leak - fork";
 
+no_leaks_ok {
+    my $redis = Redis::Cluster::Fast->new(
+        startup_nodes => get_startup_nodes,
+    );
+    $redis->del('pipeline');
+
+    $redis->set('pipeline', 12345, sub {
+        my ($result, $error) = @_;
+    });
+    $redis->get('pipeline', sub {
+        my ($result, $error) = @_;
+    });
+    $redis->get('pipeline', sub {
+        my ($result, $error) = @_;
+    });
+    $redis->wait_all_response;
+    $redis->wait_all_response;
+} "No Memory leak - pipeline wait_all_response";
+
+no_leaks_ok {
+    my $redis = Redis::Cluster::Fast->new(
+        startup_nodes => get_startup_nodes,
+    );
+    $redis->del('pipeline');
+
+    $redis->set('pipeline', 12345, sub {
+        my ($result, $error) = @_;
+    });
+    $redis->get('pipeline', sub {
+        my ($result, $error) = @_;
+    });
+    $redis->get('pipeline', sub {
+        my ($result, $error) = @_;
+    });
+    $redis->wait_one_response;
+    $redis->wait_one_response;
+} "No Memory leak - pipeline wait_one_response";
+
 done_testing;

--- a/xt/08_leak_srandom.t
+++ b/xt/08_leak_srandom.t
@@ -73,9 +73,9 @@ no_leaks_ok {
     $redis->get('pipeline', sub {
         my ($result, $error) = @_;
     });
-    $redis->wait_all_response;
-    $redis->wait_all_response;
-} "No Memory leak - pipeline wait_all_response";
+    $redis->wait_all_responses;
+    $redis->wait_all_responses;
+} "No Memory leak - pipeline wait_all_responses";
 
 no_leaks_ok {
     my $redis = Redis::Cluster::Fast->new(

--- a/xt/09_valgrind_srandom.t
+++ b/xt/09_valgrind_srandom.t
@@ -92,8 +92,8 @@ eval {
     $redis->get('pipeline', sub {
         my ($result, $error) = @_;
     });
-    $redis->wait_all_response;
-    $redis->wait_all_response;
+    $redis->wait_all_responses;
+    $redis->wait_all_responses;
 }
 
 {

--- a/xt/09_valgrind_srandom.t
+++ b/xt/09_valgrind_srandom.t
@@ -92,8 +92,8 @@ eval {
     $redis->get('pipeline', sub {
         my ($result, $error) = @_;
     });
-    $redis->wait_all_responses;
-    $redis->wait_all_responses;
+    ok $redis->wait_all_responses;
+    is $redis->wait_all_responses, 0;
 }
 
 {
@@ -111,8 +111,8 @@ eval {
     $redis->get('pipeline', sub {
         my ($result, $error) = @_;
     });
-    $redis->wait_one_response;
-    $redis->wait_one_response;
+    ok $redis->wait_one_response;
+    is $redis->wait_one_response, 0;
 }
 
 done_testing;

--- a/xt/09_valgrind_srandom.t
+++ b/xt/09_valgrind_srandom.t
@@ -77,4 +77,42 @@ eval {
     $redis_2->ping;
 }
 
+{
+    my $redis = Redis::Cluster::Fast->new(
+        startup_nodes => get_startup_nodes,
+    );
+    $redis->del('pipeline');
+
+    $redis->set('pipeline', 12345, sub {
+        my ($result, $error) = @_;
+    });
+    $redis->get('pipeline', sub {
+        my ($result, $error) = @_;
+    });
+    $redis->get('pipeline', sub {
+        my ($result, $error) = @_;
+    });
+    $redis->wait_all_response;
+    $redis->wait_all_response;
+}
+
+{
+    my $redis = Redis::Cluster::Fast->new(
+        startup_nodes => get_startup_nodes,
+    );
+    $redis->del('pipeline');
+
+    $redis->set('pipeline', 12345, sub {
+        my ($result, $error) = @_;
+    });
+    $redis->get('pipeline', sub {
+        my ($result, $error) = @_;
+    });
+    $redis->get('pipeline', sub {
+        my ($result, $error) = @_;
+    });
+    $redis->wait_one_response;
+    $redis->wait_one_response;
+}
+
 done_testing;

--- a/xt/11_fork_srandom.t
+++ b/xt/11_fork_srandom.t
@@ -41,7 +41,7 @@ if ($pid == 0) {
         my ($result, $error) = @_;
         $res = $result;
     });
-    $redis->wait_all_response;
+    $redis->wait_all_responses;
     is_deeply $res, [ 'test1', 'test2' ];
     exit 0;
 } else {
@@ -51,7 +51,7 @@ if ($pid == 0) {
         my ($result, $error) = @_;
         $res = $result;
     });
-    $redis->wait_all_response;
+    $redis->wait_all_responses;
     is_deeply $res, [ 'FOO', 'BAR' ];
     waitpid($pid, 0);
 }

--- a/xt/11_fork_srandom.t
+++ b/xt/11_fork_srandom.t
@@ -33,9 +33,19 @@ if ($pid == 0) {
 
 is $redis->get('test-fork'), 2;
 
+my $res;
+$redis->mget('{my}hoge', '{my}fuga', sub {
+    my ($result, $error) = @_;
+    $res = $result;
+});
+$redis->wait_all_responses;
+is_deeply $res, [ 'test1', 'test2' ];
+$redis->disconnect;
+
 $pid = fork;
 if ($pid == 0) {
     # child
+    $redis->connect;
     my $res;
     $redis->mget('{my}hoge', '{my}fuga', sub {
         my ($result, $error) = @_;
@@ -46,6 +56,7 @@ if ($pid == 0) {
     exit 0;
 } else {
     # parent
+    $redis->connect;
     my $res;
     $redis->mget('{my}foo', '{my}bar', sub {
         my ($result, $error) = @_;

--- a/xt/11_fork_srandom.t
+++ b/xt/11_fork_srandom.t
@@ -38,7 +38,7 @@ $redis->mget('{my}hoge', '{my}fuga', sub {
     my ($result, $error) = @_;
     $res = $result;
 });
-$redis->wait_all_responses;
+ok $redis->wait_all_responses;
 is_deeply $res, [ 'test1', 'test2' ];
 $redis->disconnect;
 
@@ -51,7 +51,7 @@ if ($pid == 0) {
         my ($result, $error) = @_;
         $res = $result;
     });
-    $redis->wait_all_responses;
+    ok $redis->wait_all_responses;
     is_deeply $res, [ 'test1', 'test2' ];
     exit 0;
 } else {
@@ -62,7 +62,7 @@ if ($pid == 0) {
         my ($result, $error) = @_;
         $res = $result;
     });
-    $redis->wait_all_responses;
+    ok $redis->wait_all_responses;
     is_deeply $res, [ 'FOO', 'BAR' ];
     waitpid($pid, 0);
 }


### PR DESCRIPTION
Resolve: #53 

Introduced pipeline functionality for Redis commands, enabling delayed execution with client-defined callbacks. Added `wait_one_response` and `wait_all_response` methods for controlled response handling in pipeline mode.